### PR TITLE
Handle KV missing content more gracefully

### DIFF
--- a/src/gChatUtils.ts
+++ b/src/gChatUtils.ts
@@ -14,7 +14,7 @@ export function imageButton(iconUrl: string, url: string) {
 
 export function kvWidget(
   topLabel: string,
-  content: string,
+  content: string | undefined,
   options?: {
     website?: {
       text: string;
@@ -24,11 +24,17 @@ export function kvWidget(
     bold?: boolean;
   }
 ): KVWidget {
+  const contentIsText = typeof content === "string" && !!content.trim();
   const isBold = !options || options?.bold || options?.bold === undefined;
   return {
     keyValue: {
       topLabel,
-      content: isBold ? `<b>${content}</b>` : content,
+      content:
+        !!content && contentIsText
+          ? isBold
+            ? `<b>${content}</b>`
+            : content
+          : "Missing field",
       contentMultiline: "true" as const,
       ...(options?.bottomLabel && { bottomLabel: options.bottomLabel }),
       ...(options?.website && {

--- a/tests/gChatUtils.test.ts
+++ b/tests/gChatUtils.test.ts
@@ -72,6 +72,16 @@ describe("gChatUtils", function() {
       const result = src.kvWidget("someLabel", "someContent", { bold: false });
       expect(result.keyValue.content).toEqual("someContent");
     });
+
+    it("Defaults the content field to 'Missing field' if given undefined", () => {
+      const result = src.kvWidget("someLabel", undefined, { bold: false });
+      expect(result.keyValue.content).toEqual("Missing field");
+    });
+
+    it("Defaults the content field to 'Missing field' if given an empty string", () => {
+      const result = src.kvWidget("someLabel", "", { bold: false });
+      expect(result.keyValue.content).toEqual("Missing field");
+    });
   });
 
   describe("sendMessageToChat", () => {


### PR DESCRIPTION
Previously, if kvWidget was given an empty string or undefined value (eg passing it some JSON from a Lambda event), it would break, causing the chat card to be invalid and not sent through.

This change checks the content before creating the key-value widget so that you would still get a card through even if the content was malformed in some way.