### PR TITLE
Add thread key fns

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,40 @@
+module.exports = {
+  env: {
+    node: true,
+    commonjs: true,
+    es6: true,
+    jest: true
+  },
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  parserOptions: {
+    ecmaVersion: 8,
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+      jsx: true
+    },
+    sourceType: "module"
+  },
+  rules: {
+    indent: ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    quotes: ["warn", "double"],
+    semi: ["error", "always"],
+    "no-console": "off",
+    "comma-dangle": "off",
+    "@typescript-eslint/camelcase": "off"
+  },
+  overrides: [
+    {
+      files: ["tests/*.test.ts"],
+      rules: {
+        "@typescript-eslint/no-use-before-define": "off"
+      }
+    }
+  ]
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/google-chat-utils",
-  "version": "1.0.4",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/google-chat-utils",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Selection of helper function and types to be used with Google Chat bots",
   "main": "dist/src/gChatUtils.js",
   "types": "dist/src/gChatUtils.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/google-chat-utils",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Selection of helper function and types to be used with Google Chat bots",
   "main": "dist/src/gChatUtils.js",
   "types": "dist/src/gChatUtils.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/google-chat-utils",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Selection of helper function and types to be used with Google Chat bots",
   "main": "dist/src/gChatUtils.js",
   "types": "dist/src/gChatUtils.d.ts",
@@ -8,7 +8,6 @@
     "test": "jest ./tests/*",
     "prepare": "npm run build",
     "prepublishOnly": "npm test",
-    "version": "npm run format && git add -A src",
     "postversion": "git push && git push --tags",
     "build": "tsc"
   },

--- a/src/gChatUtils.ts
+++ b/src/gChatUtils.ts
@@ -1,4 +1,4 @@
-import { Button, Card, ImageButton, KVWidget, Section } from "./interfaces";
+import { Button, Card, ImageButton, KVWidget } from "./interfaces";
 import fetch from "node-fetch";
 
 export const button = (title: string, url: string): Button => ({
@@ -107,4 +107,18 @@ export async function checkForBadResponse(response: {
     const json = await response.json();
     throw new Error(await JSON.stringify(json));
   }
+}
+
+// https://developers.google.com/hangouts/chat/reference/rest/v1/spaces.messages/create#query-parameters
+export function threadKey(
+  identifier: string,
+  currentDateTime: Date = new Date()
+): string {
+  return encodeURIComponent(
+    `${identifier}-${currentDateTime.toISOString().split("T")[0]}`
+  );
+}
+
+export function urlWithThreadKey(threadKey: string, webhook: string): string {
+  return `${webhook}&threadKey=${threadKey}`;
 }

--- a/tests/gChatUtils.test.ts
+++ b/tests/gChatUtils.test.ts
@@ -222,4 +222,64 @@ describe("gChatUtils", function() {
       });
     });
   });
+
+  describe("threadKey", () => {
+    test("Creates an identical thread key for two events which occur on the same day and relate to the same identifier", () => {
+      const firstThreadKey: string = src.threadKey(
+        "my-identifier-name",
+        new Date(2020, 4, 13, 8, 31)
+      );
+      const secondThreadKey: string = src.threadKey(
+        "my-identifier-name",
+        new Date(2020, 4, 13, 9, 22)
+      );
+      expect(firstThreadKey).toBe(secondThreadKey);
+    });
+
+    test("Creates a different thread key for two events which occur on the same day but relate to different identifiers", () => {
+      const firstThreadKey: string = src.threadKey(
+        "my-identifier-name",
+        new Date(2020, 4, 13, 8, 31)
+      );
+      const secondThreadKey: string = src.threadKey(
+        "different-identifier-name",
+        new Date(2020, 4, 13, 9, 22)
+      );
+      expect(firstThreadKey).not.toBe(secondThreadKey);
+    });
+
+    test("Creates a different thread key for two events which occur on different days and relate to the same identifier", () => {
+      const firstThreadKey: string = src.threadKey(
+        "my-identifier-name",
+        new Date(2020, 4, 13, 8, 31)
+      );
+      const secondThreadKey: string = src.threadKey(
+        "my-identifier-name",
+        new Date(2020, 4, 12, 9, 22)
+      );
+      expect(firstThreadKey).not.toBe(secondThreadKey);
+    });
+
+    test("Encodes special characters from the identifier name correctly", () => {
+      const actual: string = src.threadKey(
+        "My Identifier Name &?",
+        new Date(2020, 4, 13, 8, 31)
+      );
+      expect(actual).toBe("My%20Identifier%20Name%20%26%3F-2020-05-13");
+    });
+  });
+
+  describe("urlWithThreadKey", () => {
+    it("should provide a url with a thread key param", function () {
+      const url = "https://foo.com"
+      const threadKey = "my-thread-key"
+      expect(src.urlWithThreadKey(threadKey, url)).toEqual("https://foo.com&threadKey=my-thread-key")
+    });
+
+    it("should deal with special characters correctly", function () {
+      const url = "https://foo.com"
+      const threadKey = "my thread key with spaces and $ymbols"
+      expect(src.urlWithThreadKey(src.threadKey(threadKey), url)).toEqual("https://foo.com&threadKey=my%20thread%20key%20with%20spaces%20and%20%24ymbols-2020-05-18")
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Previously, each individual message would create a new thread, causing unnecessary noise.

## Solution 

Group messages by thread keys. This PR adds the capacity to generate a URL with a thread key, taking a unique identifier and the current day to form the unique ID.