### PR TITLE
Make utils more parameterizable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/google-chat-utils",
-  "version": "1.0.10",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "jest ./tests/*",
     "prepare": "npm run build",
     "prepublishOnly": "npm test",
+    "preversion": "npm test",
     "postversion": "git push && git push --tags",
     "build": "tsc"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/google-chat-utils",
-  "version": "1.0.10",
+  "version": "2.0.0",
   "description": "Selection of helper function and types to be used with Google Chat bots",
   "main": "dist/src/gChatUtils.js",
   "types": "dist/src/gChatUtils.d.ts",
@@ -36,6 +36,8 @@
     "typescript": "^3.8.3"
   },
   "jest": {
-    "modulePathIgnorePatterns": ["<rootDir>/dist/"]
+    "modulePathIgnorePatterns": [
+      "<rootDir>/dist/"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   "dependencies": {
     "node-fetch": "^2.6.0",
     "typescript": "^3.8.3"
+  },
+  "jest": {
+    "modulePathIgnorePatterns": ["<rootDir>/dist/"]
   }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,3 +1,51 @@
+export interface ButtonParams {
+  title: string;
+  url: string;
+}
+
+export interface ImageButtonParams {
+  iconUrl: string;
+  url: string;
+}
+
+export interface CardParams {
+  title: string;
+  image: string;
+  kvWidgets: KVWidget[];
+  buttons?: Button[];
+  icons?: ImageButton[];
+}
+
+export interface SendMessageParams {
+  webhook: string;
+  message: string;
+  fallbackText?: string;
+}
+
+export interface KVWidgetParams {
+  header: string;
+  footer?: string;
+  content: string;
+  website?: {
+    text: string;
+    url: string;
+  };
+  bold?: boolean;
+}
+
+export interface SendCardsParams {
+  webhook: string;
+  cards: Card[];
+  trigger: boolean;
+  fallbackText?: string;
+}
+
+export interface ThreadKeyParams {
+  identifier: string;
+  groupBy?: string | number;
+  groupByDate?: boolean;
+}
+
 // https://developers.google.com/hangouts/chat/reference/message-formats/cards#keyvalue
 export interface KVWidget {
   keyValue: {


### PR DESCRIPTION
## What does this change?

As it stands, these utils are fairly locked into a rigid implementation when they could be more flexible. For example, some functions take ordered arguments (eg `fn(someString, someBoolean)`) which makes it hard to know what needs to be passed in when importing the library elsewhere. The `kvWidget` function is a particular offender in this, as it has a mix of argument types when it would be much easier to just pass in one argument object of params.

This PR makes the various util functions parameterizable and hopefully ultimately easier to use elsewhere.

## How to test

Clone the repo and run `npm test`, the tests should still pass.

## How can we measure success?

Usages of this updated library will be cleaner to write and easier to understand.
