### PR TITLE
Add ability to click on key value widgets and improve types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/google-chat-utils",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/google-chat-utils",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/google-chat-utils",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Selection of helper function and types to be used with Google Chat bots",
   "main": "dist/src/gChatUtils.js",
   "types": "dist/src/gChatUtils.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/google-chat-utils",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Selection of helper function and types to be used with Google Chat bots",
   "main": "dist/src/gChatUtils.js",
   "types": "dist/src/gChatUtils.d.ts",

--- a/src/gChatUtils.ts
+++ b/src/gChatUtils.ts
@@ -32,13 +32,13 @@ export function kvWidget({ bold = true, ...params }: KVWidgetParams): KVWidget {
   const contentIsNotEmpty = !!params.content?.trim();
   return {
     keyValue: {
-      topLabel: params.header,
       content: contentIsNotEmpty
         ? bold
           ? `<b>${params.content}</b>`
           : params.content
         : "Missing field",
       contentMultiline: "true",
+      ...(params.header && { topLabel: params.header }),
       ...(params.footer && { bottomLabel: params.footer }),
       ...(params.website && {
         button: {

--- a/src/gChatUtils.ts
+++ b/src/gChatUtils.ts
@@ -40,6 +40,11 @@ export function kvWidget({ bold = true, ...params }: KVWidgetParams): KVWidget {
       contentMultiline: "true",
       ...(params.header && { topLabel: params.header }),
       ...(params.footer && { bottomLabel: params.footer }),
+      ...(params.onClickUrl && {
+        onClick: {
+          openLink: { url: params.onClickUrl }
+        }
+      }),
       ...(params.website && {
         button: {
           textButton: {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,8 +23,9 @@ export interface SendMessageParams {
 }
 
 export interface KVWidgetParams {
-  header: string;
+  header?: string;
   footer?: string;
+  onClick?: { openLink: { url: string } };
   content: string;
   website?: {
     text: string;
@@ -49,15 +50,11 @@ export interface ThreadKeyParams {
 // https://developers.google.com/hangouts/chat/reference/message-formats/cards#keyvalue
 export interface KVWidget {
   keyValue: {
-    topLabel: string;
+    topLabel?: string;
     content: string;
     contentMultiline?: "true" | "false";
     bottomLabel?: string;
-    onClick?: {
-      openLink: {
-        url: string;
-      };
-    };
+    onClick?: { openLink: { url: string } };
     icon?: string;
     button?: {
       textButton: {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,7 +25,7 @@ export interface SendMessageParams {
 export interface KVWidgetParams {
   header?: string;
   footer?: string;
-  onClick?: { openLink: { url: string } };
+  onClickUrl?: string;
   content: string;
   website?: {
     text: string;


### PR DESCRIPTION
## What does this change?
Following [this API guide](https://developers.google.com/hangouts/chat/reference/rest/v1/cards#KeyValue), this PR updates the types so that you can optionally pass the header (`topLabel`) and additionally pass an `onClickUrl` field to the `kvWidget` function. This means you can click on a key value widget directly to take you to a link, rather than rely on a button next to it.